### PR TITLE
Integrate toast notifications for email copy action in CommandPalette…

### DIFF
--- a/components/ui/command-palette.tsx
+++ b/components/ui/command-palette.tsx
@@ -30,6 +30,7 @@ import { FaXTwitter } from "react-icons/fa6";
 import { FiCopy, FiDownload } from "react-icons/fi";
 import { projectsData, contactData, heroContent } from "@/lib/data";
 import { useCommandPalette } from "@/contexts/command-palette-context";
+import { useToast } from "@/contexts/toast-context";
 
 interface CommandPaletteProps {
   blogPosts?: Array<{
@@ -42,6 +43,7 @@ export function CommandPalette({ blogPosts = [] }: CommandPaletteProps) {
   const { open, setOpen, toggle } = useCommandPalette();
   const router = useRouter();
   const { setTheme } = useTheme();
+  const { showToast } = useToast();
 
   // Keyboard shortcuts
   React.useEffect(() => {
@@ -93,8 +95,12 @@ export function CommandPalette({ blogPosts = [] }: CommandPaletteProps) {
   // Copy email to clipboard
   const copyEmail = React.useCallback(() => {
     navigator.clipboard.writeText(contactData.email);
-    // Could add toast notification here if you have a toast system
-  }, []);
+    showToast(
+      "Email Copied!",
+      `${contactData.email} has been copied to your clipboard`,
+      "success",
+    );
+  }, [showToast]);
 
   // Open external link
   const openLink = (url: string) => {
@@ -248,7 +254,6 @@ export function CommandPalette({ blogPosts = [] }: CommandPaletteProps) {
             onSelect={() => {
               runCommand(() => {
                 copyEmail();
-                scrollToSection("contact");
               });
             }}
             className="gap-2"


### PR DESCRIPTION
… component

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds toast feedback when copying email from the command palette and removes auto-scroll to contact section.
> 
> - **UI: `components/ui/command-palette.tsx`**
>   - Integrates `useToast` and calls `showToast` after copying `contactData.email`.
>   - Adjusts "Copy Email" action to only copy and show toast (removes `scrollToSection("contact")`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2aa990f454fe3a37738a0e9b3bde31ff52e06b9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->